### PR TITLE
Allow to set report path from REPORT_PATH env variable

### DIFF
--- a/lib/rspec_html_formatter.rb
+++ b/lib/rspec_html_formatter.rb
@@ -138,7 +138,7 @@ class RspecHtmlFormatter < RSpec::Core::Formatters::BaseFormatter
 
   RSpec::Core::Formatters.register self, :example_started, :example_passed, :example_failed, :example_pending, :example_group_finished
 
-  REPORT_PATH = './rspec_html_reports'
+  REPORT_PATH = ENV['REPORT_PATH'] || './rspec_html_reports'
 
   def initialize(io_standard_out)
     create_reports_dir


### PR DESCRIPTION
This allows to write html report to none-default directory:

``` bash
$ REPORT_PATH=test/results/html rspec ..
```

This is just a start, still need to add tests and update docs.
